### PR TITLE
remove all edits type of event and pull_request_review (because pull_…

### DIFF
--- a/.github/workflows/llm-review.yml
+++ b/.github/workflows/llm-review.yml
@@ -8,30 +8,26 @@ permissions:
 
 on:
   issues:
-    types: [opened, edited]
+    types: [ opened ]
   issue_comment:
-    types: [created, edited]
+    types: [ created ]
   pull_request:
-    types: [opened, synchronize, reopened, review_requested]
+    types: [ opened, synchronize, reopened ]
   pull_request_target:
-    types: [opened, synchronize, reopened, review_requested]
-  pull_request_review:
-    types: [submitted, edited]
+    types: [ opened, synchronize, reopened ]
   pull_request_review_comment:
-    types: [created, edited]
+    types: [ created ]
   discussion:
-    types: [created, edited]
+    types: [ created ]
   discussion_comment:
-    types: [created, edited]
+    types: [ created ]
 
 concurrency:
   group:
     ${{ github.repository }}-${{ github.event.number || github.head_ref ||
-    github.sha }}-${{ github.workflow }}-${{ github.event_name ==
-    'pull_request_review_comment' && 'pr_comment' || 
-    github.event_name == 'issue_comment' && 'issue' || 
-    github.event_name == 'discussion_comment' && 'discussion' }}
-  cancel-in-progress: true
+    github.sha }}-${{ github.workflow }}-${{ (github.event_name ==
+    'pull_request' || github.event_name == 'pull_request_target') && 'pr' || 'comment' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
 
 jobs:
   seinesailor:
@@ -41,9 +37,6 @@ jobs:
         github.event_name == 'pull_request_review_comment' ||
         github.event_name == 'discussion_comment')) ||
       (github.event_name == 'issues' && contains(github.event.issue.body, '@SeineSailor')) ||
-      ((github.event_name == 'pull_request' || 
-      github.event_name == 'pull_request_target') && contains(github.event.pull_request.body, '@SeineSailor')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@SeineSailor')) ||
       (github.event_name == 'discussion' && contains(github.event.discussion.body, '@SeineSailor'))
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
…request_review_comment will always concurrent with it); change concurrency policy, only pull request type of events need to enforce latest-only rule, all others should be allowing running independently; mentioning rules: pull requests will always get triggered, all others are comment type of jobs, will run on mention-only rules.