### PR TITLE
removed tag and api_base_url since github action said it's invalid

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,11 +119,9 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         with:
           debug: false
-          tag: stable
           llm_api_type: openai
           llm_light_model: gpt-3.5-turbo
           llm_heavy_model: gpt-4
-          api_base_url: https://api.openai.com/v1
 ```
 
 ## Usage


### PR DESCRIPTION
If the user want to use OpenAI models and followed README there might be error thrown
```
Unexpected input(s) 'tag', 'api_base_url', valid inputs are ['entryPoint', 'args', 'llm_api_type', 'debug', 'max_files', 'review_simple_changes', 'review_comment_lgtm', 'path_filters', 'disable_review', 'disable_release_notes', 'llm_base_url', 'llm_light_model', 'llm_heavy_model', 'llm_model_temperature', 'llm_retries', 'llm_timeout_ms', 'llm_concurrency_limit', 'github_concurrency_limit', 'system_message', 'summarize']
```
A bad instance
https://github.com/wentao-zh/LLMcrawler/actions/runs/9187528848

@SeineSailor